### PR TITLE
Update MiniAGI name, URL and stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@
 | GPT自动化-01-中文版  | [Auto-GPT-ZH](https://github.com/kaqijiang/Auto-GPT-ZH) | 307   | 自动化的GPT-中文版                 |                                                                                                                                     |
 | GPT自动化-02      | [AgentGPT](https://github.com/reworkd/AgentGPT) | 15.6k | 在浏览器中组装、配置和部署自动AI代理。        | 1.命名你自己的自定义AI，让它开始任何你能想到的目标。它将试图通过思考要做的任务                                                                                           |
 | GPT自动化-03      | [babyagi](https://github.com/yoheinakajima/babyagi) | 10.6k | 只需给个目标和任务迭代次数，就能让AI自动完成你的任务 | 1.命名你自己的自定义AI，让它开始任何你能想到的目标。它将试图通过思考要做的任务                                                                                           |
-| GPT自动化-04      | [micro-gpt](https://github.com/muellerberndt/micro-gpt) | 725   | 基于GPT3.5/4的最小通用自主代理。        | 1.可以分析股票价格、执行网络安全测试、创作艺术图片和订购披萨。                                                                                                    |
+| GPT自动化-04      | [MiniAGI](https://github.com/muellerberndt/mini-agi) | 2.1k   | 基于GPT3.5/4的最小通用自主代理。        | 1.可以分析股票价格、执行网络安全测试、创作艺术图片和订购披萨。                                                                                                    |
 
 
 ### 第三方机器人接入

--- a/README_en.md
+++ b/README_en.md
@@ -112,7 +112,7 @@
 | GPT Auto-01-Chinese version | [Auto-GPT-ZH](https://github.com/kaqijiang/Auto-GPT-ZH) | 307 | Auto-GPT Chinese version and hobbyist organization Synchronously update the original project AI field entrepreneurship Self-media organization Use AI work and learning to create monetization |  |
 | GPT Auto-02 | [AgentGPT](https://github.com/reworkd/AgentGPT) | 15.6k | 🤖 Assemble, configure, and deploy autonomous AI Agents in your browser. | 1. Name your own custom AI and let it start with whatever goal you can think of. It will try to do the task by thinking about it |
 | GPT Auto-03 | [babyagi](https://github.com/yoheinakajima/babyagi) | 10.6k | Just give a goal and task iteration to let the AI automate your task |  |
-| GPT Auto-04 | [micro-gpt](https://github.com/muellerberndt/micro-gpt) | 725 | A minimal generic autonomous agent based on GPT-3.5 / GPT-4. Can analyze stock prices, perform network security tests, create art, and order pizza. | 1. Can analyze stock prices, perform cybersecurity tests, create artistic pictures, and order pizza. |
+| GPT Auto-04 | [MiniAGI](https://github.com/muellerberndt/mini-agi) | 2.1k | A minimal generic autonomous agent based on GPT-3.5 / GPT-4. Can analyze stock prices, perform network security tests, create art, and order pizza. | 1. Can analyze stock prices, perform cybersecurity tests, create artistic pictures, and order pizza. |
 
 
 ### Third Platform Robot


### PR DESCRIPTION
MicroGPT was rebranded to MiniAGI. This PR corrects the project name, URL and stars. Thanks 🙂